### PR TITLE
Major MoveEntityEvent Listener optimization

### DIFF
--- a/src/main/java/com/atherys/battlegrounds/listeners/PlayerListener.java
+++ b/src/main/java/com/atherys/battlegrounds/listeners/PlayerListener.java
@@ -9,6 +9,8 @@ import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.entity.DestructEntityEvent;
 import org.spongepowered.api.event.entity.MoveEntityEvent;
 import org.spongepowered.api.event.filter.cause.Root;
+import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.World;
 
 import java.util.Optional;
 
@@ -16,19 +18,24 @@ public class PlayerListener {
 
     @Listener
     public void onPlayerMove( MoveEntityEvent event, @Root Player player ) {
-        Optional<BattlePoint> to = BattlePointManager.getInstance().getPointFromLocation( event.getToTransform().getLocation() );
-        Optional<BattlePoint> from = BattlePointManager.getInstance().getPointFromLocation( event.getFromTransform().getLocation() );
+        Location<World> fromLoc = event.getFromTransform().getLocation();
+        Location<World> toLoc = event.getToTransform().getLocation();
+        if ( fromLoc.getBlockX() != toLoc.getBlockX() || fromLoc.getBlockZ() != toLoc.getBlockZ() ) {
 
-        if ( to.isPresent() && !from.isPresent() ) {
-            BattleMsg.info( player, "You have entered ", to.get().getName() );
-        }
+            Optional<BattlePoint> to = BattlePointManager.getInstance().getPointFromLocation( event.getToTransform().getLocation() );
+            Optional<BattlePoint> from = BattlePointManager.getInstance().getPointFromLocation( event.getFromTransform().getLocation() );
 
-        if ( to.isPresent() && from.isPresent() ) {
-            BattleMsg.info( player, "You have moved from ", from.get().getName(), " to ", to.get().getName() );
-        }
+            if ( to.isPresent() && !from.isPresent() ) {
+                BattleMsg.info( player, "You have entered ", to.get().getName() );
+            }
 
-        if ( !to.isPresent() && from.isPresent() ) {
-            BattleMsg.info( player, "You have left ", from.get().getName() );
+            if ( to.isPresent() && from.isPresent() ) {
+                BattleMsg.info( player, "You have moved from ", from.get().getName(), " to ", to.get().getName() );
+            }
+
+            if ( !to.isPresent() && from.isPresent() ) {
+                BattleMsg.info( player, "You have left ", from.get().getName() );
+            }
         }
     }
 


### PR DESCRIPTION
MoveE. Event is called quite often

- An entity changes either pitch or yaw
- An entity jumps
- An entity changes a location (huh), but keep in mind that location in minecraft is measured to a few decimal digits. This is quite unnecessary and expensive unless you are in some edge case scenario.

This pr adds checks whenever a player changed actual block position before doing any more internal calls.